### PR TITLE
fix: resolve file open error on Windows

### DIFF
--- a/client/electron/main/launch-editor/index.ts
+++ b/client/electron/main/launch-editor/index.ts
@@ -29,7 +29,7 @@ function isTerminalEditor(editor: string) {
 
 function normalizePath(filename: string) {
   const { win32, posix } = path
-  return filename.split(win32.sep).join(posix.sep)
+  return filename.replaceAll(win32.sep, posix.sep)
 }
 
 const positionRE = /:(\d+)(:(\d+))?$/

--- a/client/electron/main/launch-editor/index.ts
+++ b/client/electron/main/launch-editor/index.ts
@@ -27,8 +27,14 @@ function isTerminalEditor(editor: string) {
   return false
 }
 
+function normalizePath(filename: string) {
+  const { win32, posix } = path
+  return filename.split(win32.sep).join(posix.sep)
+}
+
 const positionRE = /:(\d+)(:(\d+))?$/
 function parseFile(file: string) {
+  file = normalizePath(decodeURIComponent(file))
   const fileName = file.replace(positionRE, '')
   const match = file.match(positionRE)
   const lineNumber = match && match[1]


### PR DESCRIPTION
Close #3 .
I try to normalize filename in `parseFile`, this fixed the issue on windows where the path separators were not consistent with other platforms.
But there is another problem. Since the deeplink is tried to be opened in the `second-instance` in Windows, and the app will quit after 500ms, it is almost impossible to run successfully on Windows.